### PR TITLE
fixed two issues in metadata templates

### DIFF
--- a/src/main/resources/template/metadata_nodes_template.xml
+++ b/src/main/resources/template/metadata_nodes_template.xml
@@ -26,8 +26,7 @@
             </md:KeyDescriptor>
             $SUPPORTED_NAMEIDTYPES
             <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
-                Location="$POST_ENDPOINT" 
-                isDefault="true"/>           
+                Location="$POST_ENDPOINT" index="1" isDefault="true"/>
         </md:SPSSODescriptor>
         <md:Organization>
 			<md:OrganizationName xml:lang="$landID">$orgName</md:OrganizationName>

--- a/src/main/resources/template/metadata_service_template.xml
+++ b/src/main/resources/template/metadata_service_template.xml
@@ -24,7 +24,7 @@
                         <ds:X509Certificate>$encCert</ds:X509Certificate>
                     </ds:X509Data>
                 </ds:KeyInfo>
-                <EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes256-gcm"/>
+                <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes256-gcm"/>
             </md:KeyDescriptor>
             $SUPPORTED_NAMEIDTYPES
             <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"


### PR DESCRIPTION
1: Missing prefix for EncryptionMethod Element in service metadata.
2: Missing index attribute for AssertionConsumerService Element in connector metadata. According to https://docs.oasis-open.org/security/saml/v2.0/saml-schema-metadata-2.0.xsd AssertionConsumerService is an IndexedEndpointType which requires an index.